### PR TITLE
Fix outdated dates

### DIFF
--- a/capstone/cypress/e2e/registration.cy.js
+++ b/capstone/cypress/e2e/registration.cy.js
@@ -19,6 +19,13 @@ let validateExampleEntry = () => {
   });
 };
 
+// Helper to generate formatted DOB strings
+const formatDOBYearsAgo = (years) => {
+  const date = new Date();
+  date.setFullYear(date.getFullYear() - years);
+  return date.toISOString().split("T")[0]; // yyyy-mm-dd
+};
+
 describe("", () => {
   beforeEach(() => {
     cy.visit(Cypress.env("STUDENT_SUBMISSION_URL"));
@@ -85,16 +92,19 @@ describe("", () => {
     cy.get("#password").type("TestPass");
     cy.get("#email").type("admin@example.com");
     cy.get("input[type=checkbox]").check();
-    // Should validate min age
-    cy.get("#dob").click().type("2007-02-02");
+
+    // Should reject age < 18
+    cy.get("#dob").click().clear().type(formatDOBYearsAgo(17));
     cy.get("[type='submit']").click();
     cy.get("table").find("tr").contains("Admin User 4").should("not.exist");
-    // Should validate max age
-    cy.get("#dob").click().type("1960-02-02");
+
+    // Should reject age > 55
+    cy.get("#dob").click().clear().type(formatDOBYearsAgo(56));
     cy.get("[type='submit']").click();
     cy.get("table").find("tr").contains("Admin User 4").should("not.exist");
-    // Should save when the error is resolved
-    cy.get("#dob").click().type("1998-02-02");
+
+    // Should accept age between 18 and 55
+    cy.get("#dob").click().clear().type(formatDOBYearsAgo(25));
     cy.get("[type='submit']").click();
     cy.get("table").find("tr").contains("Admin User 4").should("exist");
   });


### PR DESCRIPTION
This pull request includes changes to the `capstone/cypress/e2e/registration.cy.js` file to improve the date of birth (DOB) validation tests. The most important changes include the addition of a helper function to generate formatted DOB strings and updates to the test cases to use this helper function for better readability and maintainability.

Improvements to DOB validation tests:

* Added a helper function `formatDOBYearsAgo` to generate formatted DOB strings based on the number of years ago.
* Updated test cases to use the `formatDOBYearsAgo` helper function, ensuring the tests reject ages under 18 and over 55, and accept ages between 18 and 55.